### PR TITLE
Change to the default distance parameters: gap_penalty_cdr3_region go…

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -14,6 +14,9 @@ Jeremy Chase Crawford (Jeremy.Crawford@stjude.org)
 
 See LICENSE.txt for details on the (MIT) license.
 
+**WARNING** (June 21 2017) I am currently updating a few input files and recomputing the "testing" inputs; this
+message will be removed when the work is done, in an hour or two. If you clone the repository now be sure
+to pull changes at the end of today.
 
 ###########################
 REQUIREMENTS

--- a/basic.py
+++ b/basic.py
@@ -27,7 +27,8 @@ pipeline_params= {
     ## distances decreased by a factor of 1.355, so as a temporary hack we introduced
     ## this parameter so that clustering and diversity calculations can be run with
     ## default parameters and give similar results.
-    'distance_threshold_25': 25.0 / 1.355,
+    #'distance_threshold_25': 25.0 / 1.355,
+    'distance_threshold_25': 25.0 / 1.298, ## now moving to a gap penalty in the CDR3 region of 12
 }
 
 
@@ -38,12 +39,6 @@ segtypes_lowercase = ['va','ja','vb','jb']
 
 ############################################################################################
 ############################################################################################
-
-def Log(s): ## silly legacy helper function
-    stderr.write(s)
-    if s and not s.endswith('\n'):
-        stderr.write('\n')
-
 
 ## you could modify this function if you have a different cmdline tool for converting svg to png
 ## like inkscape or cairosvg
@@ -128,5 +123,11 @@ def get_median(l_in):
     n = len(l)
     if n%2: return l[n/2]  ## n is odd
     else: return 0.5 * ( l[n/2] + l[n/2 - 1 ] ) ## n is even
+
+
+def Log(s): ## silly legacy helper function
+    stderr.write(s)
+    if s and not s.endswith('\n'):
+        stderr.write('\n')
 
 

--- a/rerun_paper_analysis.py
+++ b/rerun_paper_analysis.py
@@ -7,6 +7,16 @@ with Parser(locals()) as p:
     p.set_help_prefix( "\nThis script will re-run the analysis from the primary citation; it will take a few hours. Use --multicore to speed things up if you have multiple cores to burn\n" )
 
 
+
+## These are the distance parameters used in the original publication in Nature.
+##
+## Since then, we've seen evidence that a gap penalty in the CDR3 region of 12 performs slightly better.
+## So that is the new default; here the scale_factor term accounts for the difference in TCRdist values
+## (lower overall w/ classic gap penalty of 8)
+##
+distance_params='gap_penalty_v_region:4,gap_penalty_cdr3_region:8,weight_cdr3_region:3,align_cdr3s:False,distance_matrix:bsd4,trim_cdr3s:True,scale_factor:1.0439137134052388'
+
+
 for organism in ['mouse','human']:
 
     if from_pair_seqs:
@@ -17,8 +27,8 @@ for organism in ['mouse','human']:
         extra_args = ' --find_cdr3_motifs_in_parallel ' if multicore else ''
         cmd_suffix = ' &' if multicore else ''
 
-        cmd = 'nice python run_basic_analysis.py {} --organism {} --pair_seqs_file {} > {}.log 2> {}.err {}'\
-            .format( extra_args, organism, pair_seqs_file, pair_seqs_file, pair_seqs_file, cmd_suffix )
+        cmd = 'nice python run_basic_analysis.py {} --distance_params {} --organism {} --pair_seqs_file {} > {}.log 2> {}.err {}'\
+            .format( extra_args, distance_params, organism, pair_seqs_file, pair_seqs_file, pair_seqs_file, cmd_suffix )
         print cmd
         system(cmd)
         time.sleep(1.0) ## short pause
@@ -30,8 +40,8 @@ for organism in ['mouse','human']:
         extra_args = ' --find_cdr3_motifs_in_parallel ' if multicore else ''
         cmd_suffix = ' &' if multicore else ''
 
-        cmd = 'nice python run_basic_analysis.py {} --organism {} --clones_file {} > {}.log 2> {}.err {}'\
-            .format( extra_args, organism, clones_file, clones_file, clones_file, cmd_suffix )
+        cmd = 'nice python run_basic_analysis.py {} --distance_params {} --organism {} --clones_file {} > {}.log 2> {}.err {}'\
+            .format( extra_args, distance_params, organism, clones_file, clones_file, clones_file, cmd_suffix )
         print cmd
         system(cmd)
         time.sleep(1.0) ## short pause

--- a/run_basic_analysis.py
+++ b/run_basic_analysis.py
@@ -330,7 +330,7 @@ cmd = 'python {}/make_tall_trees.py --organism {} --clones_file {} --junction_ba
       .format( path_to_scripts, organism, clones_file, clones_file, clones_file )
 run(cmd)
 
-## analyze intra-mouse privacy
+## analyze intra-subject privacy
 cmd = 'python {}/analyze_epitope_privacy.py {} --organism {} --clones_file {} --all_chains AB --nrepeat 1000 --tree_height_inches 5.0 --nbrdist_percentile 10 > {}_aep.log 2> {}_aep.err'\
       .format( path_to_scripts, distance_params_args, organism, clones_file, clones_file, clones_file )
 run(cmd)


### PR DESCRIPTION
…ing from 8 to 12.

We've seen evidence that increasing this gap penalty improves performance slightly.
Also, with the factor of 3 applied to amino-acid mismatches in the CDR3, the new value
of 12 means that we are using the same gap penalty in the V and CDR3 regions, which makes
things simpler and requires fewer overall parameters.

rerun_paper_analysis.py still uses the original parameters from the paper.