### PR TITLE
Change exit code to non-zero (error) in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,19 +89,19 @@ try:
     import numpy
 except:
     print '[ERROR] failed to import numpy'
-    exit()
+    exit(1)
 
 try:
     import scipy
 except:
     print '[ERROR] failed to import scipy'
-    exit()
+    exit(1)
 
 try:
     import matplotlib
 except:
     print '[ERROR] failed to import matplotlib'
-    exit()
+    exit(1)
 
 try:
     import sklearn
@@ -146,7 +146,7 @@ if not isdir( blastdir ):
 
         if not exists( tarfile ):
             print '[ERROR] download BLAST failed!'
-            exit()
+            exit(1)
 
     cmd = 'tar -xzf '+tarfile
     print cmd
@@ -172,7 +172,7 @@ if not exists( tarfile ):
 
         if not exists( tarfile ):
             print '[ERROR] download database files failed'
-            exit()
+            exit(1)
 
 ## md5sum check
 lines = popen('md5sum '+tarfile).readlines()
@@ -199,7 +199,7 @@ if not isdir( download_dir ):
 
     if not isdir( download_dir ):
         print '[ERROR] tar failed or the database download was corrupted!'
-        exit()
+        exit(1)
 
 cmd = 'mv {}/external/* .'.format(download_dir)
 print cmd
@@ -216,4 +216,3 @@ system(cmd)
 cmd = 'mv {}/testing_ref ../'.format(download_dir)
 print cmd
 system(cmd)
-


### PR DESCRIPTION
I was trying to get `tcr-dist` into a Docker container and one of the times while testing the data download failed. Yet, the container built. The reason is that when failing `setup.py` returns the default value for `exit()` which is 0 (success). I changed that to 1 in the places I deemed appropriate so that now Docker will fail when building an image and failing to download some of the data.

I am not an expert in python at all so I may be missing something...