### PR TITLE
Align len

### DIFF
--- a/read_pair_seqs.py
+++ b/read_pair_seqs.py
@@ -62,7 +62,7 @@ default_outfields = ['id','epitope','subject',
                      'vb_blast_hits','jb_blast_hits',
                      'status' ]
 
-#assert infile.endswith('tsv') ## stupid
+
 assert outfile.endswith('tsv') ## stupid
 
 if exists(outfile): assert clobber

--- a/read_sanger_data.py
+++ b/read_sanger_data.py
@@ -381,6 +381,11 @@ def parse_unpaired_dna_sequence_blastn( organism, ab, blast_seq, info,
                             cdr3 = '{}-{}'.format(protseq,nucseq)
 
                 genes = ( v_gene, v_rep, v_mm, j_gene, j_rep, j_mm, cdr3 )
+                
+                if cdr3 != "-":
+                    cdr3aa = cdr3.split("-")[0]
+                    if len(cdr3aa) < 5:
+                        status.append('cdr3{}_len_too_short'.format(ab))
 
     if not nocleanup:
         files = glob(blast_tmpfile+'*')
@@ -515,7 +520,11 @@ def parse_unpaired_dna_sequence_blastx( organism, ab, blast_seq, info,
 
                 genes = ( v_gene, v_rep, v_mm, j_gene, j_rep, j_mm, cdr3 )
 
-
+                if cdr3 != "-":
+                    cdr3aa = cdr3.split("-")[0]
+                    if len(cdr3aa) < 5:
+                        status.append('cdr3{}_len_too_short'.format(ab))                                                                                        
+                
     if not nocleanup:
         files = glob(blast_tmpfile+'*')
         for file in files:

--- a/tcr_distances.py
+++ b/tcr_distances.py
@@ -149,7 +149,7 @@ def weighted_cdr3_distance( seq1, seq2, params ):
     assert lenshort > 1##JCC testing
     assert lendiff>=0
     if params.trim_cdr3s:
-        assert lenshort > 3+2 ## something to align...
+        assert lenshort > 3+2 ## something to align... NOTE: Minimum length of cdr3 protein carried into clones file is currently set in the read_sanger_data.py script!
 
     if not params.align_cdr3s:
         ## if we are not aligning, use a fixed gap position relative to the start of the CDR3


### PR DESCRIPTION
This change flags cdr3 protein sequences <5aa as too short, preventing their inclusion as clones. This is required to prevent errors during alignment for distance calculations using current distance script requirements, which could potentially be tweaked in the future.