### PR TITLE
Fix NCBI BLAST download URLs.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,9 +135,9 @@ blastdir = './blast-2.2.16'
 
 if not isdir( blastdir ):
     if mac_osx:
-        address = 'ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy/2.2.16/blast-2.2.16-universal-macosx.tar.gz'
+        address = 'ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy.NOTSUPPORTED/2.2.16/blast-2.2.16-universal-macosx.tar.gz'
     else:
-        address = 'ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy/2.2.16/blast-2.2.16-x64-linux.tar.gz'
+        address = 'ftp://ftp.ncbi.nlm.nih.gov/blast/executables/legacy.NOTSUPPORTED/2.2.16/blast-2.2.16-x64-linux.tar.gz'
 
     tarfile = address.split('/')[-1]
     if not exists( tarfile ):


### PR DESCRIPTION
`setup.py` was broken since NCBI changed the download URL for legacy BLAST. This fixes that.